### PR TITLE
Fix TypeError: FileExtensionUpdated() takes no arguments and Relax Asset Validation in Sentinel-3 Product

### DIFF
--- a/src/stactools/sentinel3/__init__.py
+++ b/src/stactools/sentinel3/__init__.py
@@ -13,4 +13,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_sentinel3_command)
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/stactools/sentinel3/file_extension_updated.py
+++ b/src/stactools/sentinel3/file_extension_updated.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union, cast
 
 import pystac
 from pystac.extensions.file import ByteOrder, FileExtension, MappingObject
@@ -32,10 +32,11 @@ class FileExtensionUpdated(FileExtension):
 
     @classmethod
     def ext(
-        cls, obj: pystac.Asset, add_if_missing: bool = False
+        cls, obj: Union[pystac.Asset, pystac.Link], add_if_missing: bool = False
     ) -> "FileExtensionUpdated":
-        super().ext(obj, add_if_missing)
-        return cls(obj)
+        if not isinstance(obj, pystac.Asset):
+            raise TypeError("FileExtensionUpdated only supports pystac.Asset objects.")
+        return cast(FileExtensionUpdated, super().ext(obj, add_if_missing))
 
     @classmethod
     def get_schema_uri(cls) -> str:

--- a/src/stactools/sentinel3/metadata_links.py
+++ b/src/stactools/sentinel3/metadata_links.py
@@ -144,9 +144,12 @@ class MetadataLinks:
                     band_dict_list = [band_dict_list[1]]
                 else:
                     pass
-                asset_location = self.read_href(
-                    f".//dataObject[@ID='{asset_key}']//fileLocation"
-                )
+                try:
+                    asset_location = self.read_href(
+                        f".//dataObject[@ID='{asset_key}']//fileLocation"
+                    )
+                except RuntimeError:
+                    continue
                 asset_href = os.path.join(self.granule_href, asset_location)
                 media_type = manifest.find_attr(
                     "mimeType", f".//dataObject[@ID='{asset_key}']//byteStream"
@@ -191,9 +194,12 @@ class MetadataLinks:
                             "band_width": instrument_bands[band].full_width_half_max,
                         }
                         band_dict_list.append(band_dict)
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(self.granule_href, asset_location)
                     media_type = manifest.find_attr(
                         "mimeType", f".//dataObject[@ID='{asset_key}']//byteStream"
@@ -265,9 +271,12 @@ class MetadataLinks:
                             band_dict_list.append(band_dict)
                     else:
                         band_dict_list = []
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -347,9 +356,12 @@ class MetadataLinks:
                             band_dict_list.append(band_dict)
                     else:
                         band_dict_list = []
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -415,9 +427,12 @@ class MetadataLinks:
                         band_dict_list.append(band_dict)
                     else:
                         band_dict_list = []
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(self.granule_href, asset_location)
                     media_type = manifest.find_attr(
                         "mimeType", f".//dataObject[@ID='{asset_key}']//byteStream"
@@ -470,9 +485,12 @@ class MetadataLinks:
                         "center_wavelength": instrument_bands[band].center_wavelength,
                         "band_width": instrument_bands[band].full_width_half_max,
                     }
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -511,9 +529,12 @@ class MetadataLinks:
                         band_key_list = ["Oa10", "Oa17"]
                     else:
                         band_key_list = []
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -608,9 +629,12 @@ class MetadataLinks:
                         band_key_list = []
                     else:
                         band_key_list = [asset_key[:4]]
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -665,9 +689,12 @@ class MetadataLinks:
                         "center_wavelength": instrument_bands[band].center_wavelength,
                         "band_width": instrument_bands[band].full_width_half_max,
                     }
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -697,9 +724,14 @@ class MetadataLinks:
                         band_key_list = ["S05", "S06", "S07", "S10"]
                     else:
                         band_key_list = []
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
+
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -752,9 +784,12 @@ class MetadataLinks:
                         band_key_list = ["S08", "S09"]
                     else:
                         band_key_list = []
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )
@@ -816,9 +851,12 @@ class MetadataLinks:
                             "band_width": instrument_bands[band].full_width_half_max,
                         }
                         band_dict_list.append(band_dict)
-                    asset_location = self.read_href(
-                        f".//dataObject[@ID='{asset_key}']//fileLocation"
-                    )
+                    try:
+                        asset_location = self.read_href(
+                            f".//dataObject[@ID='{asset_key}']//fileLocation"
+                        )
+                    except RuntimeError:
+                        continue
                     asset_href = os.path.join(
                         self.granule_href, strip_prefix("./", asset_location)
                     )

--- a/src/stactools/sentinel3/properties.py
+++ b/src/stactools/sentinel3/properties.py
@@ -59,7 +59,7 @@ def fill_eo_properties(eo_ext: EOExtension, manifest: XmlElement) -> None:
     def find_or_throw(attribute: str, xpath: str) -> str:
         value = manifest.find_attr(attribute, xpath)
         if value is None:
-            raise RuntimeError(f"Value not found in manifest: {xpath}@{attribute}")
+            raise RuntimeError(f"Value not in manifest: {xpath}@{attribute}")
         return value
 
     product_name = xml.find_text(manifest, ".//sentinel3:productName")


### PR DESCRIPTION
**Related Issue(s):**
- https://github.com/stactools-packages/sentinel3/issues/31

**Description:**
This PR addresses a critical issue causing a TypeError due to the improper definition or invocation of the FileExtensionUpdated() function. Additionally, it relaxes the asset validation logic for Sentinel-3 products to enhance compatibility and flexibility.

Bump to version 0.4.1

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
